### PR TITLE
Handle Digital Sensor on PA3 with Debouncing Using TIM3

### DIFF
--- a/include/firmware.h
+++ b/include/firmware.h
@@ -59,12 +59,18 @@ int _write(int file, char* ptr, int len);
 #define MAX_TEMPERATURE 60.0
 #define MIN_DUTY_CYCLE  0
 #define MAX_DUTY_CYCLE  1000
-
 enum
 {
     ADC_CHANNEL_GROUND_HUMIDITY = 0,
     ADC_CHANNEL_TEMPERATURE = 1
 };
+
+extern struct timekeeper
+{
+    uint8_t hours;
+    uint8_t minutes;
+    uint8_t seconds;
+} time;
 
 /**
  * @brief Initialize and configure hardware.
@@ -125,5 +131,6 @@ uint16_t mapTemperatureToDutyCycle(float temperature);
 void process_received_message(void);
 /**
  * @brief function to create a string with the current time
+ * @param time Timekeeper struct with time values to be converted to string
  */
-char* get_time(void);
+char* get_time(struct timekeeper time);


### PR DESCRIPTION
## Summary
This pull request implements external interrupts to handle a digital sensor for sunlight

## Changes Made

- Configured PA3 as a digital input.
- Set up EXTI for PA3 to trigger an interrupt on both rising and falling edges.
- Configured TIM3 to handle debouncing.
- Implemented the EXTI interrupt handler to start the debounce timer.

Design note: Implemented a flag to represent which input asked for debounce in order to expand the debounce timer utilization for other digital inputs.

## Diagrams

### Digital Sensor Handling with Debouncing and Variable Update

```mermaid
sequenceDiagram
    participant Sensor as Digital Sensor (PA3)
    participant EXTI as EXTI3 ISR
    participant Timer as TIM3 ISR
    participant Variables as Variables (sunrise, sunset)

    Sensor->>EXTI: Trigger interrupt
    EXTI->>EXTI: Clear interrupt flag
    EXTI->>Timer: Start debounce timer
    Timer->>Timer: Wait for debounce period
    alt Input is high
        Timer->>Variables: Set sunset
    else Input is low
        Timer->>Variables: Set sunrise
    end