### PR TITLE
Fire handler detection through a digital sensor

### DIFF
--- a/include/firmware.h
+++ b/include/firmware.h
@@ -17,9 +17,10 @@ int _write(int file, char* ptr, int len);
 #include "queue.h"
 #include "semphr.h"
 #include "stdio.h"
+#include "string.h"
 #include "task.h"
 #include "timers.h"
-#include "string.h"
+
 
 #include <libopencm3/cm3/nvic.h>
 #include <libopencm3/stm32/adc.h>
@@ -32,11 +33,11 @@ int _write(int file, char* ptr, int len);
 #include <libopencm3/stm32/usart.h>
 
 /* UART configuration */
-#define BAUD_RATE   115200
-#define WORD_LENGTH 8
-#define FIRE_ALARM_DELAY            5*SECOND_DELAY
-#define REPORT_DELAY                15*SECOND_DELAY
-#define MEASURE_DELAY               5*SECOND_DELAY
+#define BAUD_RATE                   115200
+#define WORD_LENGTH                 8
+#define FIRE_ALARM_DELAY            5 * SECOND_DELAY
+#define REPORT_DELAY                15 * SECOND_DELAY
+#define MEASURE_DELAY               5 * SECOND_DELAY
 #define TIMER_PERIOD_1S             10000
 #define TIMER_PRESCALE_VALUE        71999
 #define BUFFER_SIZE                 64
@@ -59,7 +60,7 @@ int _write(int file, char* ptr, int len);
 #define ADC_TEMP_MAX_VALUE          1861
 #define MAX_TEMP                    150
 #define NUMBER_OF_DECIMALS          2
-
+#define FIRE_ALARM_REPEATS          15
 /* PWM definitions */
 #define MIN_TEMPERATURE 20.0
 #define MAX_TEMPERATURE 60.0
@@ -154,4 +155,11 @@ void xtaskFireAlarm(void* args __attribute__((unused)));
  */
 void xTaskCreateReport(void* args __attribute__((unused)));
 
+/**
+ * @brief function that takes a float and converts it to a string
+ * Casts the float to an integer and decimal part, then converts them to string and concatenates them into two elements
+ * in the returned array
+ * @param f Float value to be converted
+ * @param number_of_decimals Number of decimals to be used
+ */
 char* float_to_string(float f, int number_of_decimals);

--- a/include/firmware.h
+++ b/include/firmware.h
@@ -19,6 +19,7 @@ int _write(int file, char* ptr, int len);
 #include "stdio.h"
 #include "task.h"
 #include "timers.h"
+#include "string.h"
 
 #include <libopencm3/cm3/nvic.h>
 #include <libopencm3/stm32/adc.h>
@@ -33,7 +34,9 @@ int _write(int file, char* ptr, int len);
 /* UART configuration */
 #define BAUD_RATE   115200
 #define WORD_LENGTH 8
-
+#define FIRE_ALARM_DELAY            5*SECOND_DELAY
+#define REPORT_DELAY                15*SECOND_DELAY
+#define MEASURE_DELAY               5*SECOND_DELAY
 #define TIMER_PERIOD_1S             10000
 #define TIMER_PRESCALE_VALUE        71999
 #define BUFFER_SIZE                 64
@@ -49,11 +52,14 @@ int _write(int file, char* ptr, int len);
 #define tskGROUND_HUMIDITY_PRIORITY tskIDLE_PRIORITY + 2
 #define tskTEMPERATURE_PRIORITY     tskIDLE_PRIORITY + 2
 #define tskCOMMUNICATION_PRIORITY   tskIDLE_PRIORITY + 2
+#define tskFIRE_ALARM_PRIORITY      tskIDLE_PRIORITY + 3
 #define BUFFER_MESSAGE_SIZE         64
 #define TIME_STRING_SIZE            9
 #define UART_BUFFER_SIZE            64
 #define ADC_TEMP_MAX_VALUE          1861
 #define MAX_TEMP                    150
+#define NUMBER_OF_DECIMALS          2
+
 /* PWM definitions */
 #define MIN_TEMPERATURE 20.0
 #define MAX_TEMPERATURE 60.0
@@ -134,3 +140,18 @@ void process_received_message(void);
  * @param time Timekeeper struct with time values to be converted to string
  */
 char* get_time(struct timekeeper time);
+
+/**
+ * @brief Task to create fire SOS messages and send them over UART
+ * Fire alarm dies once it's triggered enough time and fire is not detected
+ * @param args Task arguments (not used)
+ */
+void xtaskFireAlarm(void* args __attribute__((unused)));
+
+/**
+ * @brief Task to create a report with the current time and send it over UART
+ * @param args Task arguments (not used)
+ */
+void xTaskCreateReport(void* args __attribute__((unused)));
+
+char* float_to_string(float f, int number_of_decimals);

--- a/lib/rtos/FreeRTOSConfig.h
+++ b/lib/rtos/FreeRTOSConfig.h
@@ -114,7 +114,7 @@ to exclude the API function. */
 
 #define INCLUDE_vTaskPrioritySet	0
 #define INCLUDE_uxTaskPriorityGet	0
-#define INCLUDE_vTaskDelete		0
+#define INCLUDE_vTaskDelete		1
 #define INCLUDE_vTaskCleanUpResources	0
 #define INCLUDE_vTaskSuspend		0
 #define INCLUDE_vTaskDelayUntil		0

--- a/src/firmware.c
+++ b/src/firmware.c
@@ -171,8 +171,9 @@ void xtaskFireAlarm(void* args __attribute__((unused)))
             xQueueSend(xUartQueue, message, portMAX_DELAY);
             xSemaphoreGive(xCommunicationSemaphore);
         }
-        if (fire_alarm_times_counter > 15 && gpio_get(GPIOA, GPIO2))
+        if (fire_alarm_times_counter > 5 && gpio_get(GPIOA, GPIO2))
         {
+            exti_reset_request(EXTI2);
             nvic_enable_irq(NVIC_EXTI2_IRQ);
             vTaskDelete(xFireHandler);
             

--- a/src/firmware.c
+++ b/src/firmware.c
@@ -134,7 +134,6 @@ void prvSetupHardware(void)
     exti_set_trigger(EXTI2, EXTI_TRIGGER_FALLING);
     exti_enable_request(EXTI2);
     nvic_enable_irq(NVIC_EXTI2_IRQ);
-    
 }
 
 void prvSetupTasks(void)
@@ -171,12 +170,11 @@ void xtaskFireAlarm(void* args __attribute__((unused)))
             xQueueSend(xUartQueue, message, portMAX_DELAY);
             xSemaphoreGive(xCommunicationSemaphore);
         }
-        if (fire_alarm_times_counter > 5 && gpio_get(GPIOA, GPIO2))
+        if (fire_alarm_times_counter > FIRE_ALARM_REPEATS && gpio_get(GPIOA, GPIO2))
         {
             exti_reset_request(EXTI2);
             nvic_enable_irq(NVIC_EXTI2_IRQ);
             vTaskDelete(xFireHandler);
-            
         }
         vTaskDelay(pdMS_TO_TICKS(FIRE_ALARM_DELAY));
     }
@@ -229,7 +227,7 @@ void xTaskCreateReport(void* args __attribute__((unused)))
 {
     char message[BUFFER_MESSAGE_SIZE];
     while (true)
-    {  
+    {
         xSemaphoreTake(xCommunicationSemaphore, portMAX_DELAY);
         sprintf(message, "Sunrise: %s ", get_time(sunrise));
         xQueueSend(xUartQueue, message, portMAX_DELAY);
@@ -370,14 +368,17 @@ void process_received_message()
         if (sscanf(uart_buffer + 3, "%02d%02d%02d", &hours, &minutes, &seconds) == 3)
         {
             // Update the clock variables
-            if(hours<24){
-            time.hours = hours;
+            if (hours < 24)
+            {
+                time.hours = hours;
             }
-            if(minutes<60){
-            time.minutes = minutes;
+            if (minutes < 60)
+            {
+                time.minutes = minutes;
             }
-            if(seconds<60){
-            time.seconds = seconds;
+            if (seconds < 60)
+            {
+                time.seconds = seconds;
             }
         }
     }
@@ -397,7 +398,8 @@ void exti3_isr()
 
 void exti2_isr()
 {
-    if(xFireHandler == NULL){
+    if (xFireHandler == NULL)
+    {
         xTaskCreate(xtaskFireAlarm, "FireAlarm", configMINIMAL_STACK_SIZE, tskFIRE_ALARM_PRIORITY, 1, xFireHandler);
     }
     exti_reset_request(EXTI2);


### PR DESCRIPTION
## Summary
This pull request implements a fire detecting digital sensor, configuration for it's GPIO function and interruption, along with it's ISR and a task dedicated to it. Also implemented a function to turn floats into chars for easier communication.

## Changes Made

1. Firmware Initialization: Added PA2 as a digital input, configured as an external interrupt with falling flank trigger
2. Combining Variable Communication: The xTaskCreateReport function needs to combine all variable communication into a single task.
3. Fire EXTI Implementation: Implemented the fire EXTI, its ISR, and the xtaskFireAlarm task to handle fire alarm events

### Design Choices and known issues:

- EXTI falling flank (due to the sensor's nature) will trigger the ISR where the fire handler task is created, once it's done so the interruption is disabled until the task is done. Task will communicate the emergency message along with the temperature variable, once it's been repeated a configurable amount of times and the fire is no longer detected, the task will delete itself and re-activate the interruption.
- Known Issue: despite clearing flags on both the ISR and the ending of the task, if there's a falling flank during the task's lifespan it will re-trigger the ISR after coming out of the task. 

## Diagrams
### State Machine Diagram

``` mermaid
stateDiagram
    [*] --> Idle
    Idle --> EXTI2_ISR : Interrupt
    EXTI2_ISR --> xtaskFireAlarm : xTaskCreate and NVIC disabling of EXTI
    xtaskFireAlarm --> Delete_Task : Repeated over n times and fire not present
    Delete_Task --> Idle : Re-enable NVIC interrupt and Task Deleted
    
```
### Sequence Diagram

``` mermaid
sequenceDiagram
    participant EXTI_Event as EXTI Event
    participant EXTI_ISR as EXTI ISR
    participant NVIC as NVIC
    participant Task as xtaskFireAlarm
    participant Semaphore as xCommunicationSemaphore
    participant Queue as xUartQueue

    EXTI_Event ->> EXTI_ISR: Trigger EXTI ISR
    EXTI_ISR ->> NVIC: Disable EXTI2 Interrupt
    EXTI_ISR ->> EXTI_ISR: Clear EXTI Pending Bit
    EXTI_ISR ->> Task: Create xtaskFireAlarm Task
    Task ->> Task: Handle Fire Alarm
    Task ->> Semaphore: Take Semaphore
    Semaphore -->> Task: Semaphore Taken
    Task ->> Queue: Send Message to Queue
    Task ->> Semaphore: Give Semaphore
    Task ->> Task: Check Fire Condition
    alt Fire Condition Cleared
        Task ->> EXTI_ISR: Clear EXTI Pending Bit
        Task ->> NVIC: Re-enable EXTI2 Interrupt
        Task ->> Task: Reset Task Handle
        Task ->> Task: Delete Task
    else Fire Condition Present
        Task ->> Task: Continue Handling Fire Alarm
    end
```