### PR TITLE
fixed uart isr and task

### DIFF
--- a/include/firmware.h
+++ b/include/firmware.h
@@ -21,7 +21,6 @@ int _write(int file, char* ptr, int len);
 #include "task.h"
 #include "timers.h"
 
-
 #include <libopencm3/cm3/nvic.h>
 #include <libopencm3/stm32/adc.h>
 #include <libopencm3/stm32/dma.h>
@@ -163,3 +162,9 @@ void xTaskCreateReport(void* args __attribute__((unused)));
  * @param number_of_decimals Number of decimals to be used
  */
 char* float_to_string(float f, int number_of_decimals);
+
+/**
+ * @brief Function to process messages recieved via UART
+ * @param args Task arguments (not used)
+ */
+void xTaskProcessMessage(void* args __attribute__((unused)));


### PR DESCRIPTION
## Summary
This pull request implements fixes and improvements to UART communication

## Changes Made

- Implemented a check for `rclk` (report clock) in parsing so the system can respond with system time
- Created xTaskProcessMessage in order to offload work from the isr
- Added uart buffer clearing once an endline / end of message is detected
- Added a secondary queue to handle message reception, separate from the one used for transmission


``` mermaid
sequenceDiagram
    participant USART as USART
    participant ISR as USART ISR
    participant Queue as xUartQueue
    participant Task as xTaskProcessMessage

    USART ->> ISR: Receive Character
    ISR ->> ISR: Check for Endline
    alt Endline Received
        ISR ->> Queue: Send Message to Queue
        ISR ->> ISR: Clear Buffer
        ISR ->> Task: Yield to Higher Priority Task
    else No Endline
        ISR ->> ISR: Store Character in Buffer
    end
    Task ->> Queue: Receive Message from Queue
    Task ->> Task: Process Message
    alt Message is "clk"
        Task ->> Task: Update Clock Variables
    else Message is "rclk"
        Task ->> Queue: Send Current Time to Queue
    end
```